### PR TITLE
feat(AAE-102): Added START_MESSAGE_DEPLOYED cloud api implementation

### DIFF
--- a/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/CloudStartMessageDeploymentDefinitionImpl.java
+++ b/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/CloudStartMessageDeploymentDefinitionImpl.java
@@ -28,11 +28,11 @@ public class CloudStartMessageDeploymentDefinitionImpl extends CloudRuntimeEntit
     
     private ProcessDefinition processDefinition;
     
-    private StartMessageSubscription messageEventSubscription;
+    private StartMessageSubscription messageSubscription;
 
     private CloudStartMessageDeploymentDefinitionImpl(Builder builder) {
         this.processDefinition = builder.processDefinition;
-        this.messageEventSubscription = builder.messageEventSubscription;
+        this.messageSubscription = builder.messageSubscription;
         super.setAppName(builder.appName);
         super.setAppVersion(builder.appVersion);
         super.setServiceName(builder.serviceName);
@@ -50,11 +50,11 @@ public class CloudStartMessageDeploymentDefinitionImpl extends CloudRuntimeEntit
 
     @Override
     public StartMessageSubscription getMessageSubscription() {
-        return messageEventSubscription;
+        return messageSubscription;
     }
     @Override
     public int hashCode() {
-        return Objects.hash(messageEventSubscription, processDefinition);
+        return Objects.hash(messageSubscription, processDefinition);
     }
 
     @Override
@@ -69,7 +69,7 @@ public class CloudStartMessageDeploymentDefinitionImpl extends CloudRuntimeEntit
             return false;
         }
         CloudStartMessageDeploymentDefinitionImpl other = (CloudStartMessageDeploymentDefinitionImpl) obj;
-        return Objects.equals(messageEventSubscription, other.messageEventSubscription) && 
+        return Objects.equals(messageSubscription, other.messageSubscription) && 
                Objects.equals(processDefinition, other.processDefinition);
     }
 
@@ -78,8 +78,8 @@ public class CloudStartMessageDeploymentDefinitionImpl extends CloudRuntimeEntit
         StringBuilder builder = new StringBuilder();
         builder.append("CloudStartMessageDeploymentDefinitionImpl [processDefinition=")
                .append(processDefinition)
-               .append(", messageEventSubscription=")
-               .append(messageEventSubscription)
+               .append(", messageSubscription=")
+               .append(messageSubscription)
                .append("]");
         return builder.toString();
     }
@@ -94,7 +94,7 @@ public class CloudStartMessageDeploymentDefinitionImpl extends CloudRuntimeEntit
     public static final class Builder {
 
         private ProcessDefinition processDefinition;
-        private StartMessageSubscription messageEventSubscription;
+        private StartMessageSubscription messageSubscription;
         private String appName;
         private String appVersion;
         private String serviceName;
@@ -117,11 +117,11 @@ public class CloudStartMessageDeploymentDefinitionImpl extends CloudRuntimeEntit
 
         /**
         * Builder method for messageEventSubscription parameter.
-        * @param messageEventSubscription field to set
+        * @param messageSubscription field to set
         * @return builder
         */
-        public Builder withMessageEventSubscription(StartMessageSubscription messageEventSubscription) {
-            this.messageEventSubscription = messageEventSubscription;
+        public Builder withMessageSubscription(StartMessageSubscription messageSubscription) {
+            this.messageSubscription = messageSubscription;
             return this;
         }
 

--- a/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/CloudStartMessageDeploymentDefinitionImpl.java
+++ b/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/CloudStartMessageDeploymentDefinitionImpl.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.api.process.model.impl;
+
+import java.util.Objects;
+
+import org.activiti.api.process.model.MessageEventSubscription;
+import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.cloud.api.model.shared.impl.CloudRuntimeEntityImpl;
+import org.activiti.cloud.api.process.model.CloudStartMessageDeploymentDefinition;
+
+public class CloudStartMessageDeploymentDefinitionImpl extends CloudRuntimeEntityImpl 
+                                                       implements CloudStartMessageDeploymentDefinition {
+    
+    private ProcessDefinition processDefinition;
+    
+    private MessageEventSubscription messageEventSubscription;
+
+    private CloudStartMessageDeploymentDefinitionImpl(Builder builder) {
+        this.processDefinition = builder.processDefinition;
+        this.messageEventSubscription = builder.messageEventSubscription;
+        super.setAppName(builder.appName);
+        super.setAppVersion(builder.appVersion);
+        super.setServiceName(builder.serviceName);
+        super.setServiceFullName(builder.serviceFullName);
+        super.setServiceType(builder.serviceType);
+        super.setServiceVersion(builder.serviceVersion);
+    }
+    
+    CloudStartMessageDeploymentDefinitionImpl() { }
+
+    @Override
+    public ProcessDefinition getProcessDefinition() {
+        return processDefinition;
+    }
+
+    @Override
+    public MessageEventSubscription getMessageEventSubscription() {
+        return messageEventSubscription;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(messageEventSubscription, processDefinition);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        CloudStartMessageDeploymentDefinitionImpl other = (CloudStartMessageDeploymentDefinitionImpl) obj;
+        return Objects.equals(messageEventSubscription, other.messageEventSubscription) && 
+               Objects.equals(processDefinition, other.processDefinition);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("CloudStartMessageDeploymentDefinitionImpl [processDefinition=")
+               .append(processDefinition)
+               .append(", messageEventSubscription=")
+               .append(messageEventSubscription)
+               .append("]");
+        return builder.toString();
+    }
+    
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link CloudStartMessageDeploymentDefinitionImpl}.
+     */
+    public static final class Builder {
+
+        private ProcessDefinition processDefinition;
+        private MessageEventSubscription messageEventSubscription;
+        private String appName;
+        private String appVersion;
+        private String serviceName;
+        private String serviceFullName;
+        private String serviceType;
+        private String serviceVersion;
+
+        public Builder() {
+        }
+
+        /**
+        * Builder method for processDefinition parameter.
+        * @param processDefinition field to set
+        * @return builder
+        */
+        public Builder withProcessDefinition(ProcessDefinition processDefinition) {
+            this.processDefinition = processDefinition;
+            return this;
+        }
+
+        /**
+        * Builder method for messageEventSubscription parameter.
+        * @param messageEventSubscription field to set
+        * @return builder
+        */
+        public Builder withMessageEventSubscription(MessageEventSubscription messageEventSubscription) {
+            this.messageEventSubscription = messageEventSubscription;
+            return this;
+        }
+
+        /**
+        * Builder method for appName parameter.
+        * @param appName field to set
+        * @return builder
+        */
+        public Builder withAppName(String appName) {
+            this.appName = appName;
+            return this;
+        }
+
+        /**
+        * Builder method for appVersion parameter.
+        * @param appVersion field to set
+        * @return builder
+        */
+        public Builder withAppVersion(String appVersion) {
+            this.appVersion = appVersion;
+            return this;
+        }
+
+        /**
+        * Builder method for serviceName parameter.
+        * @param serviceName field to set
+        * @return builder
+        */
+        public Builder withServiceName(String serviceName) {
+            this.serviceName = serviceName;
+            return this;
+        }
+
+        /**
+        * Builder method for serviceFullName parameter.
+        * @param serviceFullName field to set
+        * @return builder
+        */
+        public Builder withServiceFullName(String serviceFullName) {
+            this.serviceFullName = serviceFullName;
+            return this;
+        }
+
+        /**
+        * Builder method for serviceType parameter.
+        * @param serviceType field to set
+        * @return builder
+        */
+        public Builder withServiceType(String serviceType) {
+            this.serviceType = serviceType;
+            return this;
+        }
+
+        /**
+        * Builder method for serviceVersion parameter.
+        * @param serviceVersion field to set
+        * @return builder
+        */
+        public Builder withServiceVersion(String serviceVersion) {
+            this.serviceVersion = serviceVersion;
+            return this;
+        }
+
+        /**
+        * Builder method of the builder.
+        * @return built class
+        */
+        public CloudStartMessageDeploymentDefinitionImpl build() {
+            return new CloudStartMessageDeploymentDefinitionImpl(this);
+        }
+    }
+
+}

--- a/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/CloudStartMessageDeploymentDefinitionImpl.java
+++ b/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/CloudStartMessageDeploymentDefinitionImpl.java
@@ -18,8 +18,8 @@ package org.activiti.cloud.api.process.model.impl;
 
 import java.util.Objects;
 
-import org.activiti.api.process.model.MessageEventSubscription;
 import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.api.process.model.StartMessageSubscription;
 import org.activiti.cloud.api.model.shared.impl.CloudRuntimeEntityImpl;
 import org.activiti.cloud.api.process.model.CloudStartMessageDeploymentDefinition;
 
@@ -28,7 +28,7 @@ public class CloudStartMessageDeploymentDefinitionImpl extends CloudRuntimeEntit
     
     private ProcessDefinition processDefinition;
     
-    private MessageEventSubscription messageEventSubscription;
+    private StartMessageSubscription messageEventSubscription;
 
     private CloudStartMessageDeploymentDefinitionImpl(Builder builder) {
         this.processDefinition = builder.processDefinition;
@@ -49,7 +49,7 @@ public class CloudStartMessageDeploymentDefinitionImpl extends CloudRuntimeEntit
     }
 
     @Override
-    public MessageEventSubscription getMessageEventSubscription() {
+    public StartMessageSubscription getMessageEventSubscription() {
         return messageEventSubscription;
     }
 
@@ -95,7 +95,7 @@ public class CloudStartMessageDeploymentDefinitionImpl extends CloudRuntimeEntit
     public static final class Builder {
 
         private ProcessDefinition processDefinition;
-        private MessageEventSubscription messageEventSubscription;
+        private StartMessageSubscription messageEventSubscription;
         private String appName;
         private String appVersion;
         private String serviceName;
@@ -121,7 +121,7 @@ public class CloudStartMessageDeploymentDefinitionImpl extends CloudRuntimeEntit
         * @param messageEventSubscription field to set
         * @return builder
         */
-        public Builder withMessageEventSubscription(MessageEventSubscription messageEventSubscription) {
+        public Builder withMessageEventSubscription(StartMessageSubscription messageEventSubscription) {
             this.messageEventSubscription = messageEventSubscription;
             return this;
         }

--- a/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/CloudStartMessageDeploymentDefinitionImpl.java
+++ b/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/CloudStartMessageDeploymentDefinitionImpl.java
@@ -49,10 +49,9 @@ public class CloudStartMessageDeploymentDefinitionImpl extends CloudRuntimeEntit
     }
 
     @Override
-    public StartMessageSubscription getMessageEventSubscription() {
+    public StartMessageSubscription getMessageSubscription() {
         return messageEventSubscription;
     }
-
     @Override
     public int hashCode() {
         return Objects.hash(messageEventSubscription, processDefinition);

--- a/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/conf/CloudProcessModelAutoConfiguration.java
+++ b/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/conf/CloudProcessModelAutoConfiguration.java
@@ -16,29 +16,24 @@
 
 package org.activiti.cloud.api.process.model.impl.conf;
 
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.DeserializationConfig;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.activiti.api.process.model.events.BPMNActivityEvent;
 import org.activiti.api.process.model.events.BPMNErrorReceivedEvent;
 import org.activiti.api.process.model.events.BPMNMessageEvent;
 import org.activiti.api.process.model.events.BPMNSignalEvent;
 import org.activiti.api.process.model.events.BPMNTimerEvent;
 import org.activiti.api.process.model.events.IntegrationEvent;
+import org.activiti.api.process.model.events.MessageDefinitionEvent;
 import org.activiti.api.process.model.events.ProcessDefinitionEvent;
 import org.activiti.api.process.model.events.ProcessRuntimeEvent;
 import org.activiti.api.process.model.events.SequenceFlowEvent;
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
+import org.activiti.cloud.api.process.model.CloudStartMessageDeploymentDefinition;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.IntegrationResult;
 import org.activiti.cloud.api.process.model.impl.CloudProcessDefinitionImpl;
 import org.activiti.cloud.api.process.model.impl.CloudProcessInstanceImpl;
+import org.activiti.cloud.api.process.model.impl.CloudStartMessageDeploymentDefinitionImpl;
 import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
 import org.activiti.cloud.api.process.model.impl.IntegrationResultImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudBPMNActivityCancelledEventImpl;
@@ -66,8 +61,18 @@ import org.activiti.cloud.api.process.model.impl.events.CloudProcessStartedEvent
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessSuspendedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessUpdatedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudSequenceFlowTakenImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudStartMessageDeployedEventImpl;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @Configuration
 public class CloudProcessModelAutoConfiguration {
@@ -87,6 +92,8 @@ public class CloudProcessModelAutoConfiguration {
                                               BPMNSignalEvent.SignalEvents.SIGNAL_RECEIVED.name()));
         module.registerSubtypes(new NamedType(CloudProcessDeployedEventImpl.class,
                                               ProcessDefinitionEvent.ProcessDefinitionEvents.PROCESS_DEPLOYED.name()));
+        module.registerSubtypes(new NamedType(CloudStartMessageDeployedEventImpl.class,
+                                              MessageDefinitionEvent.MessageDefinitionEvents.START_MESSAGE_DEPLOYED.name()));
         module.registerSubtypes(new NamedType(CloudProcessStartedEventImpl.class,
                                               ProcessRuntimeEvent.ProcessEvents.PROCESS_STARTED.name()));
         module.registerSubtypes(new NamedType(CloudProcessCreatedEventImpl.class,
@@ -148,6 +155,8 @@ public class CloudProcessModelAutoConfiguration {
 
         resolver.addMapping(CloudProcessDefinition.class,
                             CloudProcessDefinitionImpl.class);
+        resolver.addMapping(CloudStartMessageDeploymentDefinition.class,
+                            CloudStartMessageDeploymentDefinitionImpl.class);
         resolver.addMapping(CloudProcessInstance.class,
                             CloudProcessInstanceImpl.class);
 

--- a/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/conf/CloudProcessModelAutoConfiguration.java
+++ b/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/conf/CloudProcessModelAutoConfiguration.java
@@ -16,6 +16,14 @@
 
 package org.activiti.cloud.api.process.model.impl.conf;
 
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.activiti.api.process.model.events.BPMNActivityEvent;
 import org.activiti.api.process.model.events.BPMNErrorReceivedEvent;
 import org.activiti.api.process.model.events.BPMNMessageEvent;
@@ -23,6 +31,7 @@ import org.activiti.api.process.model.events.BPMNSignalEvent;
 import org.activiti.api.process.model.events.BPMNTimerEvent;
 import org.activiti.api.process.model.events.IntegrationEvent;
 import org.activiti.api.process.model.events.MessageDefinitionEvent;
+import org.activiti.api.process.model.events.MessageSubscriptionEvent;
 import org.activiti.api.process.model.events.ProcessDefinitionEvent;
 import org.activiti.api.process.model.events.ProcessRuntimeEvent;
 import org.activiti.api.process.model.events.SequenceFlowEvent;
@@ -38,20 +47,21 @@ import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
 import org.activiti.cloud.api.process.model.impl.IntegrationResultImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudBPMNActivityCancelledEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudBPMNActivityCompletedEventImpl;
-import org.activiti.cloud.api.process.model.impl.events.CloudBPMNSignalReceivedEventImpl;
-import org.activiti.cloud.api.process.model.impl.events.CloudBPMNTimerCancelledEventImpl;
-import org.activiti.cloud.api.process.model.impl.events.CloudBPMNTimerFailedEventImpl;
-import org.activiti.cloud.api.process.model.impl.events.CloudBPMNTimerExecutedEventImpl;
-import org.activiti.cloud.api.process.model.impl.events.CloudBPMNTimerFiredEventImpl;
-import org.activiti.cloud.api.process.model.impl.events.CloudBPMNTimerRetriesDecrementedEventImpl;
-import org.activiti.cloud.api.process.model.impl.events.CloudBPMNTimerScheduledEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudBPMNActivityStartedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudBPMNErrorReceivedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudBPMNMessageReceivedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudBPMNMessageSentEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudBPMNMessageWaitingEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudBPMNSignalReceivedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudBPMNTimerCancelledEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudBPMNTimerExecutedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudBPMNTimerFailedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudBPMNTimerFiredEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudBPMNTimerRetriesDecrementedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudBPMNTimerScheduledEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudIntegrationRequestedImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudIntegrationResultReceivedImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudMessageSubscriptionCancelledEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCancelledEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCompletedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCreatedEventImpl;
@@ -64,15 +74,6 @@ import org.activiti.cloud.api.process.model.impl.events.CloudSequenceFlowTakenIm
 import org.activiti.cloud.api.process.model.impl.events.CloudStartMessageDeployedEventImpl;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.DeserializationConfig;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @Configuration
 public class CloudProcessModelAutoConfiguration {
@@ -138,6 +139,9 @@ public class CloudProcessModelAutoConfiguration {
         
         module.registerSubtypes(new NamedType(CloudBPMNErrorReceivedEventImpl.class,
                                               BPMNErrorReceivedEvent.ErrorEvents.ERROR_RECEIVED.name()));
+        
+        module.registerSubtypes(new NamedType(CloudMessageSubscriptionCancelledEventImpl.class,
+                                              MessageSubscriptionEvent.MessageSubscriptionEvents.MESSAGE_SUBSCRIPTION_CANCELLED.name()));
 
         SimpleAbstractTypeResolver resolver = new SimpleAbstractTypeResolver() {
             //this is a workaround for https://github.com/FasterXML/jackson-databind/issues/2019

--- a/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudMessageSubscriptionCancelledEventImpl.java
+++ b/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudMessageSubscriptionCancelledEventImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.api.process.model.impl.events;
+
+import org.activiti.api.process.model.MessageSubscription;
+import org.activiti.api.process.model.events.MessageSubscriptionEvent;
+import org.activiti.api.process.model.events.MessageSubscriptionEvent.MessageSubscriptionEvents;
+import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
+import org.activiti.cloud.api.process.model.events.CloudMessageSubscriptionCancelledEvent;
+
+public class CloudMessageSubscriptionCancelledEventImpl  extends CloudRuntimeEventImpl<MessageSubscription, MessageSubscriptionEvent.MessageSubscriptionEvents> implements CloudMessageSubscriptionCancelledEvent {
+
+    public CloudMessageSubscriptionCancelledEventImpl() {
+    }
+
+    public CloudMessageSubscriptionCancelledEventImpl(MessageSubscription entity,
+                                           String processDefinitionId,
+                                           String processInstanceId) {
+        super(entity);    
+        
+        setProcessInstanceId(entity.getProcessInstanceId());
+        setProcessDefinitionId(entity.getProcessDefinitionId());
+        
+        if (entity!=null) {
+            setEntityId(entity.getActivityId());
+        }
+    }
+    
+    public CloudMessageSubscriptionCancelledEventImpl(String id,
+                                           Long timestamp,
+                                           MessageSubscription entity,
+                                           String processDefinitionId,
+                                           String processInstanceId) {
+        super(id,
+              timestamp,
+              entity);
+        
+        setProcessDefinitionId(processDefinitionId);
+        setProcessInstanceId(processInstanceId);
+        
+        if (entity!=null) {
+            setEntityId(entity.getActivityId());
+        }
+    }
+    
+    @Override
+    public MessageSubscriptionEvent.MessageSubscriptionEvents getEventType() {
+        return MessageSubscriptionEvents.MESSAGE_SUBSCRIPTION_CANCELLED;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("CloudMessageSubscriptionCancelledEventImpl [getEventType()=")
+               .append(getEventType())
+               .append(", toString()=")
+               .append(super.toString())
+               .append("]");
+        return builder.toString();
+    }
+}

--- a/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudMessageSubscriptionCancelledEventImpl.java
+++ b/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudMessageSubscriptionCancelledEventImpl.java
@@ -22,21 +22,24 @@ import org.activiti.api.process.model.events.MessageSubscriptionEvent.MessageSub
 import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
 import org.activiti.cloud.api.process.model.events.CloudMessageSubscriptionCancelledEvent;
 
-public class CloudMessageSubscriptionCancelledEventImpl  extends CloudRuntimeEventImpl<MessageSubscription, MessageSubscriptionEvent.MessageSubscriptionEvents> implements CloudMessageSubscriptionCancelledEvent {
+public class CloudMessageSubscriptionCancelledEventImpl extends CloudRuntimeEventImpl<MessageSubscription, MessageSubscriptionEvent.MessageSubscriptionEvents> 
+                                                        implements CloudMessageSubscriptionCancelledEvent {
 
-    public CloudMessageSubscriptionCancelledEventImpl() {
+    private CloudMessageSubscriptionCancelledEventImpl(Builder builder) {
+       this(builder.entity);
     }
 
-    public CloudMessageSubscriptionCancelledEventImpl(MessageSubscription entity,
-                                           String processDefinitionId,
-                                           String processInstanceId) {
+    CloudMessageSubscriptionCancelledEventImpl() {
+    }
+
+    public CloudMessageSubscriptionCancelledEventImpl(MessageSubscription entity) {
         super(entity);    
         
         setProcessInstanceId(entity.getProcessInstanceId());
         setProcessDefinitionId(entity.getProcessDefinitionId());
         
         if (entity!=null) {
-            setEntityId(entity.getActivityId());
+            setEntityId(entity.getId());
         }
     }
     
@@ -53,7 +56,7 @@ public class CloudMessageSubscriptionCancelledEventImpl  extends CloudRuntimeEve
         setProcessInstanceId(processInstanceId);
         
         if (entity!=null) {
-            setEntityId(entity.getActivityId());
+            setEntityId(entity.getId());
         }
     }
     
@@ -71,5 +74,74 @@ public class CloudMessageSubscriptionCancelledEventImpl  extends CloudRuntimeEve
                .append(super.toString())
                .append("]");
         return builder.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Creates a builder to build {@link CloudMessageSubscriptionCancelledEventImpl}.
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    /**
+     * Creates a builder to build {@link CloudMessageSubscriptionCancelledEventImpl} and initialize it with the given object.
+     * @param cloudMessageSubscriptionCancelledEventImpl to initialize the builder with
+     * @return created builder
+     */
+    public static Builder builderFrom(CloudMessageSubscriptionCancelledEventImpl cloudMessageSubscriptionCancelledEventImpl) {
+        return new Builder(cloudMessageSubscriptionCancelledEventImpl);
+    }
+
+    /**
+     * Builder to build {@link CloudMessageSubscriptionCancelledEventImpl}.
+     */
+    public static final class Builder {
+
+        private MessageSubscription entity;
+
+        public Builder() {
+        }
+
+        private Builder(CloudMessageSubscriptionCancelledEventImpl cloudMessageSubscriptionCancelledEventImpl) {
+            this.entity = cloudMessageSubscriptionCancelledEventImpl.getEntity();
+        }
+
+        /**
+        * Builder method for entity parameter.
+        * @param entity field to set
+        * @return builder
+        */
+        public Builder withEntity(MessageSubscription entity) {
+            this.entity = entity;
+            return this;
+        }
+
+        /**
+        * Builder method of the builder.
+        * @return built class
+        */
+        public CloudMessageSubscriptionCancelledEventImpl build() {
+            return new CloudMessageSubscriptionCancelledEventImpl(this);
+        }
     }
 }

--- a/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudStartMessageDeployedEventImpl.java
+++ b/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudStartMessageDeployedEventImpl.java
@@ -34,7 +34,7 @@ public class CloudStartMessageDeployedEventImpl extends CloudRuntimeEventImpl<St
     public CloudStartMessageDeployedEventImpl(StartMessageDeploymentDefinition entity) {
         super(entity);
         
-        setEntityId(entity.getMessageEventSubscription().getId());
+        setEntityId(entity.getMessageSubscription().getId());
         
         setProcessDefinitionId(entity.getProcessDefinition().getId());
         setProcessDefinitionKey(entity.getProcessDefinition().getKey());
@@ -47,7 +47,7 @@ public class CloudStartMessageDeployedEventImpl extends CloudRuntimeEventImpl<St
         super(id, timestamp, entity);
         
         if (getEntity() != null)
-            setEntityId(getEntity().getMessageEventSubscription().getId());
+            setEntityId(getEntity().getMessageSubscription().getId());
     }    
 
     @Override

--- a/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudStartMessageDeployedEventImpl.java
+++ b/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudStartMessageDeployedEventImpl.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.api.process.model.impl.events;
+
+import org.activiti.api.process.model.StartMessageDeploymentDefinition;
+import org.activiti.api.process.model.events.MessageDefinitionEvent;
+import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
+import org.activiti.cloud.api.process.model.events.CloudStartMessageDeployedEvent;
+
+public class CloudStartMessageDeployedEventImpl extends CloudRuntimeEventImpl<StartMessageDeploymentDefinition, 
+                                                                              MessageDefinitionEvent.MessageDefinitionEvents> 
+                                                implements CloudStartMessageDeployedEvent {
+
+    private CloudStartMessageDeployedEventImpl(Builder builder) {
+        super.setEntity(builder.entity);
+    }
+
+    CloudStartMessageDeployedEventImpl() { }
+    
+    public CloudStartMessageDeployedEventImpl(StartMessageDeploymentDefinition entity) {
+        super(entity);
+        
+        setEntityId(entity.getMessageEventSubscription().getId());
+        
+        setProcessDefinitionId(entity.getProcessDefinition().getId());
+        setProcessDefinitionKey(entity.getProcessDefinition().getKey());
+        setProcessDefinitionVersion(entity.getProcessDefinition().getVersion());
+    }
+    
+    public CloudStartMessageDeployedEventImpl(String id,
+                                              Long timestamp,
+                                              StartMessageDeploymentDefinition entity) {
+        super(id, timestamp, entity);
+        
+        if (getEntity() != null)
+            setEntityId(getEntity().getMessageEventSubscription().getId());
+    }    
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("CloudStartMessageDeployedEventImpl []");
+        return builder.toString();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    /**
+     * Creates a builder to build {@link CloudStartMessageDeployedEventImpl} and initialize it with the given object.
+     * @param cloudStartMessageDeployedEventImpl to initialize the builder with
+     * @return created builder
+     */
+    public static Builder builderFrom(CloudStartMessageDeployedEventImpl cloudStartMessageDeployedEventImpl) {
+        return new Builder(cloudStartMessageDeployedEventImpl);
+    }
+
+    /**
+     * Builder to build {@link CloudStartMessageDeployedEventImpl}.
+     */
+    public static final class Builder {
+
+        private StartMessageDeploymentDefinition entity;
+
+        public Builder() {
+        }
+
+        private Builder(CloudStartMessageDeployedEventImpl cloudStartMessageDeployedEventImpl) {
+            this.entity = cloudStartMessageDeployedEventImpl.getEntity();
+        }
+
+        /**
+        * Builder method for entity parameter.
+        * @param entity field to set
+        * @return builder
+        */
+        public Builder withEntity(StartMessageDeploymentDefinition entity) {
+            this.entity = entity;
+            return this;
+        }
+
+        /**
+        * Builder method of the builder.
+        * @return built class
+        */
+        public CloudStartMessageDeployedEventImpl build() {
+            return new CloudStartMessageDeployedEventImpl(this);
+        }
+    }
+    
+}

--- a/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/CloudStartMessageDeploymentDefinition.java
+++ b/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/CloudStartMessageDeploymentDefinition.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.api.process.model;
+
+import org.activiti.api.process.model.StartMessageDeploymentDefinition;
+import org.activiti.cloud.api.model.shared.CloudRuntimeEntity;
+
+public interface CloudStartMessageDeploymentDefinition extends CloudRuntimeEntity, 
+                                                               StartMessageDeploymentDefinition {
+
+}

--- a/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/events/CloudMessageSubscriptionCancelledEvent.java
+++ b/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/events/CloudMessageSubscriptionCancelledEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.api.process.model.events;
+
+import org.activiti.api.process.model.MessageSubscription;
+import org.activiti.api.process.model.events.MessageSubscriptionEvent;
+import org.activiti.api.process.model.events.MessageSubscriptionEvent.MessageSubscriptionEvents;
+import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+
+public interface CloudMessageSubscriptionCancelledEvent extends CloudRuntimeEvent<MessageSubscription, MessageSubscriptionEvent.MessageSubscriptionEvents> {
+
+    @Override
+    default MessageSubscriptionEvents getEventType() {
+        return MessageSubscriptionEvents.MESSAGE_SUBSCRIPTION_CANCELLED;
+    }
+    
+}
+

--- a/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/events/CloudStartMessageDeployedEvent.java
+++ b/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/events/CloudStartMessageDeployedEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.api.process.model.events;
+
+import org.activiti.api.process.model.StartMessageDeploymentDefinition;
+import org.activiti.api.process.model.events.MessageDefinitionEvent;
+import org.activiti.api.process.model.events.StartMessageDeployedEvent;
+import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+
+public interface CloudStartMessageDeployedEvent extends CloudRuntimeEvent<StartMessageDeploymentDefinition, MessageDefinitionEvent.MessageDefinitionEvents>,
+                                                        StartMessageDeployedEvent {
+
+    @Override
+    default MessageDefinitionEvents getEventType() {
+        return MessageDefinitionEvents.START_MESSAGE_DEPLOYED;
+    }
+
+}


### PR DESCRIPTION
This PR adds CloudStartMessageDeploymentDefinition event api implementation

Depends on https://github.com/Activiti/activiti-api/pull/151

Part of https://github.com/Activiti/Activiti/issues/1691