### PR TITLE
fix: Revert changes for activiti-build parent and activiti-core-dependencies propagation

### DIFF
--- a/activiti-cloud-api-dependencies/pom.xml
+++ b/activiti-cloud-api-dependencies/pom.xml
@@ -13,13 +13,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.activiti.api</groupId>
-        <artifactId>activiti-api-dependencies</artifactId>
-        <version>${activiti-api.version}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-      <dependency>
         <groupId>org.activiti.cloud.api</groupId>
         <artifactId>activiti-cloud-api-model-shared</artifactId>
         <version>${activiti-cloud-api.version}</version>

--- a/activiti-cloud-api-dependencies/pom.xml
+++ b/activiti-cloud-api-dependencies/pom.xml
@@ -20,13 +20,6 @@
         <type>pom</type>
       </dependency>
       <dependency>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-core-dependencies</artifactId>
-        <version>${activiti-core.version}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-      <dependency>
         <groupId>org.activiti.cloud.api</groupId>
         <artifactId>activiti-cloud-api-model-shared</artifactId>
         <version>${activiti-cloud-api.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
   <properties>
     <activiti-cloud-api.version>${project.version}</activiti-cloud-api.version>
     <activiti-cloud-build.version>7.1.30</activiti-cloud-build.version>
-    <activiti-core.version>7.1.181</activiti-core.version>
     <activiti-api.version>7.1.181</activiti-api.version>
   </properties>
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <activiti-cloud-api.version>${project.version}</activiti-cloud-api.version>
     <activiti-cloud-build.version>7.1.30</activiti-cloud-build.version>
-    <activiti-api.version>7.1.181</activiti-api.version>
+    <activiti-api.version>7.1.182</activiti-api.version>
   </properties>
   <modules>
     <module>dependencies-tests</module>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,13 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <dependency>
+        <groupId>org.activiti.api</groupId>
+        <artifactId>activiti-api-dependencies</artifactId>
+        <version>${activiti-api.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <!-- BoMs markers for dependency convergence tests -->


### PR DESCRIPTION
This PR fixes changes for activiti-build parent and activiti-core-dependencies propagation

Part of https://github.com/Activiti/Activiti/issues/3099